### PR TITLE
std::time::Instant is not compatible with WASM target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["gui", "asynchronous"]
 dioxus-core = "0.4"
 dioxus-hooks = "0.4"
 futures-util = "0.3.28"
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 [dev-dependencies]
 dioxus = "0.4"

--- a/src/cached_result.rs
+++ b/src/cached_result.rs
@@ -1,8 +1,5 @@
-use std::{
-    fmt::Debug,
-    ops::Deref,
-    time::{Duration, Instant},
-};
+use instant::Instant;
+use std::{fmt::Debug, ops::Deref, time::Duration};
 
 use crate::result::QueryResult;
 

--- a/src/use_query_client.rs
+++ b/src/use_query_client.rs
@@ -4,13 +4,13 @@ use futures_util::{
     future::BoxFuture,
     stream::{FuturesUnordered, StreamExt},
 };
+use instant::Instant;
 use std::{
     any::TypeId,
     collections::{HashMap, HashSet},
     hash::Hash,
     rc::Rc,
     sync::{Arc, RwLock},
-    time::Instant,
 };
 
 use crate::{cached_result::CachedResult, result::QueryResult};


### PR DESCRIPTION
When I try to use it in wasm32 target, it panicked at 'time not implemented on this platform'.