### PR TITLE
feat: Simplification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dioxus-query"
 description = "Fully-typed, async, reusable cached state management for Dioxus 🧬"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 authors = ["Marc Espín <mespinsanz@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 See the [Docs](https://docs.rs/dioxus-query/latest/dioxus_query/) or join the [Discord](https://discord.gg/gwuU8vGRPr). 
 
-⚠️ **Work in progress ⚠️**
-
 ## Support
 
 - **Dioxus v0.6** 🧬

--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ async fn fetch_user(keys: Vec<QueryKey>) -> QueryResult<QueryValue, QueryError> 
             0 => Ok(QueryValue::UserName("Marc".to_string())),
             _ => Err(QueryError::UserNotFound(*id)),
         }
-        .into()
     } else {
-        QueryResult::Err(QueryError::Unknown)
+        Err(QueryError::Unknown)
     }
 }
 
@@ -69,11 +68,10 @@ fn User(id: usize) -> Element {
 }
 
 fn app() -> Element {
-    use_init_query_client::<QueryValue, QueryError, QueryKey>();
-    let client = use_query_client::<QueryValue, QueryError, QueryKey>();
+    let client = use_init_query_client::<QueryValue, QueryError, QueryKey>();
 
     let onclick = move |_| {
-         client.invalidate_query(QueryKey::User(0));
+         client.invalidate_queries(&[QueryKey::User(0)]);
     };
 
     rsx!(
@@ -91,6 +89,9 @@ fn app() -> Element {
 - [x] Invalidate queries when keys change
 - [x] Concurrent and batching of queries
 - [x] Concurrent mutations
+- [ ] Background interval invalidation
+- [ ] On window focus invalidation
+
 
 ## To Do
 - Tests

--- a/examples/complex_queries.rs
+++ b/examples/complex_queries.rs
@@ -33,9 +33,8 @@ async fn fetch_user(keys: Vec<QueryKey>) -> QueryResult<QueryValue, ()> {
             1 => Ok(QueryValue::UserName("Evan".to_string())),
             _ => Err(()),
         }
-        .into()
     } else {
-        QueryResult::Err(())
+        Err(())
     }
 }
 
@@ -68,12 +67,12 @@ fn app() -> Element {
     let client = use_query_client::<QueryValue, (), QueryKey>();
 
     let refresh_0 = move |_| {
-        client.invalidate_query(QueryKey::User(0));
+        client.invalidate_queries(&[QueryKey::User(0)]);
     };
 
     let refresh_1 = move |_| client.invalidate_queries(&[QueryKey::User(1)]);
 
-    let refresh_all = move |_| client.invalidate_query(QueryKey::Users);
+    let refresh_all = move |_| client.invalidate_queries(&[QueryKey::Users]);
 
     rsx!(
         User { id: 0 }

--- a/examples/mutations.rs
+++ b/examples/mutations.rs
@@ -24,7 +24,7 @@ enum MutationValue {
 async fn update_user((id, _name): (usize, String)) -> MutationResult<MutationValue, MutationError> {
     println!("Mutating user");
     sleep(Duration::from_millis(1000)).await;
-    Ok(MutationValue::UserUpdated(id)).into()
+    Ok(MutationValue::UserUpdated(id))
 }
 
 #[allow(non_snake_case)]
@@ -33,7 +33,7 @@ fn User(id: usize) -> Element {
     let mutate = use_mutation(update_user);
 
     let onclick = move |_| {
-        mutate.mutate((0, "Not Marc".to_string()));
+        mutate.mutate((id, "Not Marc".to_string()));
     };
 
     println!("Rendering user {id}");

--- a/src/cached_result.rs
+++ b/src/cached_result.rs
@@ -1,20 +1,18 @@
 use instant::Instant;
 use std::{fmt::Debug, ops::Deref, time::Duration};
 
-use crate::result::QueryResult;
-
-const STALE_TIME: u64 = 100;
+use crate::result::QueryState;
 
 /// Cached result.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CachedResult<T, E> {
-    pub(crate) value: QueryResult<T, E>,
+    pub(crate) value: QueryState<T, E>,
     pub(crate) instant: Option<Instant>,
-    pub(crate) has_been_queried: bool,
+    pub(crate) has_been_loaded: bool,
 }
 
 impl<T, E> CachedResult<T, E> {
-    pub fn new(value: QueryResult<T, E>) -> Self {
+    pub fn new(value: QueryState<T, E>) -> Self {
         Self {
             value,
             ..Default::default()
@@ -22,33 +20,40 @@ impl<T, E> CachedResult<T, E> {
     }
 
     /// Get this result's value
-    pub fn value(&self) -> &QueryResult<T, E> {
+    pub fn value(&self) -> &QueryState<T, E> {
         &self.value
     }
 
-    /// Check if this result has been mutated recently
-    pub fn is_fresh(&self) -> bool {
+    /// Set this result's value
+    pub fn set_value(&mut self, new_value: QueryState<T, E>) {
+        self.value = new_value;
+        self.instant = Some(Instant::now());
+    }
+
+    /// Check if this result is stale yet
+    pub fn is_fresh(&self, stale_time: Duration) -> bool {
         if let Some(instant) = self.instant {
-            instant.elapsed().as_millis() < Duration::from_millis(STALE_TIME).as_millis()
+            instant.elapsed() < stale_time
         } else {
             false
         }
     }
 
-    /// Check if this result has queried it's actual value yet
-    pub(crate) fn has_been_queried(&self) -> bool {
-        self.has_been_queried
+    /// Check if this result has loaded yet
+    pub(crate) fn has_been_loaded(&self) -> bool {
+        self.has_been_loaded
     }
 
+    /// Set this result as loading
     pub(crate) fn set_to_loading(&mut self) {
         self.value.set_loading();
         self.instant = Some(Instant::now());
-        self.has_been_queried = true;
+        self.has_been_loaded = true;
     }
 }
 
 impl<T, E> Deref for CachedResult<T, E> {
-    type Target = QueryResult<T, E>;
+    type Target = QueryState<T, E>;
 
     fn deref(&self) -> &Self::Target {
         &self.value
@@ -60,7 +65,7 @@ impl<T, E> Default for CachedResult<T, E> {
         Self {
             value: Default::default(),
             instant: None,
-            has_been_queried: false,
+            has_been_loaded: false,
         }
     }
 }


### PR DESCRIPTION
- Query and mutations functions now just return a `Result<T, E>`, which allows using `?`
- Stale time can be configured in each query
- `invalidate_query` is removed, just use `invalidate_queries`
- `manual_mutate` is now called `mutate_async`