### PR TITLE
feat: add query revalidation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ futures-util = "0.3.28"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 warnings = "0.2.1"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = {version = "^1", features = ["time"]}
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-async-std = "^1"
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasmtimer = "0.4.1"
 
 [dev-dependencies]
 dioxus = { version = "0.6", features = ["desktop"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,12 @@ futures-util = "0.3.28"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 warnings = "0.2.1"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = {version = "^1", features = ["time"]}
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+async-std = "^1"
+
 [dev-dependencies]
 dioxus = { version = "0.6", features = ["desktop"] }
 tokio = { version = "1.29.1", features = ["time"] }

--- a/examples/complex_queries.rs
+++ b/examples/complex_queries.rs
@@ -58,8 +58,23 @@ fn AnotherUser(id: usize) -> Element {
     });
 
     println!("Rendering another user {id}");
+    rsx!(p { "{value.result().value():?}" })
+}
 
-    rsx!( p { "{value.result().value():?}" } )
+#[allow(non_snake_case)]
+#[component]
+fn AutoUpdatingUser(id: usize) -> Element {
+    let value = use_query([QueryKey::User(id)], || {
+        Query::new(fetch_user).revalidate(Duration::from_secs(3))
+    });
+    println!("Rendering auto-updating user {id}");
+
+    rsx!(
+        div {
+            p { "Auto-updating every 3 seconds:" }
+            p { "{value.result().value():?}" }
+        }
+    )
 }
 
 fn app() -> Element {
@@ -80,5 +95,9 @@ fn app() -> Element {
         button { onclick: refresh_0, label { "Refresh 0" } }
         button { onclick: refresh_1, label { "Refresh 1" } }
         button { onclick: refresh_all, label { "Refresh all" } }
+
+        h1 { "Auto-revalidating Query" }
+        p { "This query automatically updates with a timestamp every 3 seconds" }
+        AutoUpdatingUser { id: 0 }
     )
 }

--- a/src/cached_result.rs
+++ b/src/cached_result.rs
@@ -1,3 +1,4 @@
+use dioxus_lib::prelude::*;
 use instant::Instant;
 use std::{fmt::Debug, ops::Deref, time::Duration};
 
@@ -9,6 +10,7 @@ pub struct CachedResult<T, E> {
     pub(crate) value: QueryState<T, E>,
     pub(crate) instant: Option<Instant>,
     pub(crate) has_been_loaded: bool,
+    pub(crate) revalidation_options: Option<RevalidationOptions>,
 }
 
 impl<T, E> CachedResult<T, E> {
@@ -28,6 +30,13 @@ impl<T, E> CachedResult<T, E> {
     pub(crate) fn set_value(&mut self, new_value: QueryState<T, E>) {
         self.value = new_value;
         self.instant = Some(Instant::now());
+    }
+
+    pub(crate) fn set_revalidate_options(
+        &mut self,
+        revalidate_options: Option<RevalidationOptions>,
+    ) {
+        self.revalidation_options = revalidate_options;
     }
 
     /// Check if this result is stale yet
@@ -66,6 +75,13 @@ impl<T, E> Default for CachedResult<T, E> {
             value: Default::default(),
             instant: None,
             has_been_loaded: false,
+            revalidation_options: None,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RevalidationOptions {
+    pub(crate) interval: Duration,
+    pub(crate) task: Task,
 }

--- a/src/use_query.rs
+++ b/src/use_query.rs
@@ -141,7 +141,7 @@ impl<T, E, K> Query<T, E, K> {
 
     /// Set the revalidation interval for the query.
     /// The query will be automatically refetched at this interval.
-    pub fn revalidate(mut self, interval: Duration) -> Self {
+    pub fn interval(mut self, interval: Duration) -> Self {
         self.revalidate_interval = Some(interval);
         self
     }

--- a/src/use_query_client.rs
+++ b/src/use_query_client.rs
@@ -157,10 +157,11 @@ where
                     let task = spawn(async move {
                         loop {
                             // Wait for the specified interval, using the appropriate sleep function.
-                            #[cfg(not(target_arch = "wasm32"))]
+                            #[cfg(not(target_family = "wasm"))]
                             tokio::time::sleep(interval).await;
-                            #[cfg(target_arch = "wasm32")]
-                            async_std::time::sleep(interval).await;
+                            #[cfg(target_family = "wasm")]
+                            wasmtimer::tokio::sleep(interval).await;
+
                             self_clone.invalidate_queries(&query_keys);
                         }
                     });

--- a/src/use_query_client.rs
+++ b/src/use_query_client.rs
@@ -145,6 +145,10 @@ where
             .map(|o| o.interval)
             != revalidate_interval
         {
+            // Drop the existing task, if it exists.
+            if let Some(task) = value.borrow().revalidation_options.as_ref().map(|o| o.task) {
+                task.cancel();
+            }
             let new_revalidate_options = match revalidate_interval {
                 // When we do have an interval to update with, we set up a task to revalidate the query.
                 Some(interval) => {
@@ -168,9 +172,6 @@ where
                 // When we don't have an interval to update with, set the revalidation options to None.
                 None => None,
             };
-            if let Some(task) = value.borrow().revalidation_options.as_ref().map(|o| o.task) {
-                task.cancel();
-            }
             value
                 .borrow_mut()
                 .set_revalidate_options(new_revalidate_options);


### PR DESCRIPTION
Includes an example via `cargo run --example complex_queries`

Went with a very simple implementation, so very open to feedback and improvements 😁

For the `sleep` utility, I piggy-backed off of how [dioxus-timer](https://github.com/asobininn/dioxus-timer/blob/main/src/lib.rs#L10) does things, which is also similar to [dioxus-sdk's](https://github.com/DioxusLabs/sdk/blob/main/sdk/src/utils/timing/interval.rs#L40). I was searching for a way to do this via more "native, low-level" dioxus, but this was the best I came up with so far.

The decision to override the revalidate_interval in cases where different values are set in different places mimics react-query's functionality: https://github.com/TanStack/query/blob/main/packages/query-core/src/queryObserver.ts#L214