### PR TITLE
fix: mutation loading state

### DIFF
--- a/src/use_mutation.rs
+++ b/src/use_mutation.rs
@@ -161,7 +161,7 @@ impl<T, E> MutationState<T, E> {
     }
 
     pub fn set_loading(&mut self) {
-        let result = mem::replace(self, Self::Pending).into();
+        let result = mem::replace(self, Self::Loading(None)).into();
         if let Some(v) = result {
             *self = Self::Loading(Some(v))
         }


### PR DESCRIPTION
The first call to a mutation stays on the Pending state instead of `Loading(None)`. This PR fixes it so that called mutations get properly set to `Loading`, even when they don't have a value.

The update more directly matches the behavior in `QueryState.set_loading`.