### PR TITLE
fix: Avoid data race in query subscription by making mutation creation synchronous in `use_mutation`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dioxus-query"
 description = "Fully-typed, async, reusable cached state management for Dioxus 🧬"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 authors = ["Marc Espín <mespinsanz@gmail.com>"]


### PR DESCRIPTION
Closes https://github.com/marc2332/dioxus-query/issues/47

Same as https://github.com/marc2332/dioxus-query/pull/48 but for mutations, also simplifies the code